### PR TITLE
fix: add image and definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function (options) {
   }
 
   function transform(tree) {
-    visit(tree, ['link', 'linkReference'], visitor);
+    visit(tree, ["link", "image", "definition"], visitor);
   }
 
   return transform;

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ module.exports = function (options) {
   }
 
   function transform(tree) {
-    visit(tree, ['link', 'linkReference'], visitor);
+    visit(tree, ["link", "image", "definition"], visitor);
   }
 
   return transform;


### PR DESCRIPTION
changes to `visit`:
- removed: `"linkReference"` -> [`LinkReference`](https://github.com/syntax-tree/mdast/blob/main/readme.md#linkreference) not include `Resource`
- added: `"image"` -> [`Image`](https://github.com/syntax-tree/mdast/blob/main/readme.md#image) include `Resource`
- added: `"definition"` -> [`Definition`](https://github.com/syntax-tree/mdast/blob/main/readme.md#definition) include `Resource`
