### PR TITLE
add: allow parameter be a string for command line usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ remark()
 <p><a href="/blog/article/">Blog</a></p>
 ```
 
+### Command Line
+
+```shell
+remark ./test.md -u "remark-relative-links=domainRegex:'/http[s]*:\/\/[www.]*yoursite\.com[/]?/'" -u remark-html > ./test.html
+```
+
+
 ## API
 
 ### `remark.use(relativeLinks[, options])`
@@ -42,7 +49,7 @@ Add target and rel attributes to external links.
 
 ###### `options.domainRegex` **Required**
 
-Regex used to decipher what domain to "relative-ize". The example provided should handle most cases.
+Regex or Regex-String used to decipher what domain to "relative-ize". The example provided should handle most cases.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ remark()
 ### Command Line
 
 ```shell
-remark ./test.md -u "remark-relative-links=domainRegex:'/http[s]*:\/\/[www.]*yoursite\.com[/]?/'" -u remark-html > ./test.html
+remark ./test.md -u "remark-relative-links=domainRegex:'http[s]*:\/\/[www.]*yoursite\.com[/]?'" -u remark-html > ./test.html
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ remark()
 
 ### Command Line
 
-```shell
+```bash
 remark ./test.md -u "remark-relative-links=domainRegex:'http[s]*:\/\/[www.]*yoursite\.com[/]?'" -u remark-html > ./test.html
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ remark()
 ### Command Line
 
 ```bash
-remark ./test.md -u "remark-relative-links=domainRegex:'http[s]*:\/\/[www.]*yoursite\.com[/]?'" -u remark-html > ./test.html
+remark ./test.md -u "remark-relative-links=domainRegex:'http[s]?:\/\/(www\.)?yoursite\.com[/]?'" -u remark-html > ./test.html
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ remark()
 remark ./test.md -u "remark-relative-links=domainRegex:'http[s]*:\/\/[www.]*yoursite\.com[/]?'" -u remark-html > ./test.html
 ```
 
-
 ## API
 
 ### `remark.use(relativeLinks[, options])`

--- a/index.js
+++ b/index.js
@@ -5,9 +5,20 @@ module.exports = function (options) {
     throw Error('Missing required "domainRegex" option');
   }
 
+  let domainRegex = options.domainRegex;
+
+  // special for plain strings: they are not "instanceof String"
+  if (typeof domainRegex === "string") {
+    domainRegex = new RegExp(domainRegex);
+  }
+
+  if (!domainRegex instanceof RegExp) {
+    throw Error('Required "domainRegex" option need to be a RegEx or RegExp-String');
+  }
+
   function visitor(node) {
-    if (options.domainRegex.test(node.url)) {
-      node.url = node.url.replace(options.domainRegex, '/');
+    if (domainRegex.test(node.url)) {
+      node.url = node.url.replace(domainRegex, '/');
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,20 @@ module.exports = function (options) {
     throw Error('Missing required "domainRegex" option');
   }
 
+  let domainRegex = options.domainRegex
+
+  // special for plain strings: they are not "instanceof String"
+  if (typeof domainRegex === "string"){
+    domainRegex = new RegExp(domainRegex);
+  }
+
+  if (!domainRegex instanceof RegExp) {
+    throw Error('Required "domainRegex" option need to be a RegEx or RegExp-String');
+  }
+
   function visitor(node) {
-    if (options.domainRegex.test(node.url)) {
-      node.url = node.url.replace(options.domainRegex, '/');
+    if (domainRegex.test(node.url)) {
+      node.url = node.url.replace(domainRegex, '/');
     }
   }
 


### PR DESCRIPTION
changes:
- add type checks for `RegExp`
- convert string into `RegExp`
- add command line usage to README